### PR TITLE
[fix] update show.html to resolve typo

### DIFF
--- a/presentation/templates/posts/show.html
+++ b/presentation/templates/posts/show.html
@@ -16,7 +16,7 @@
 
     <hr/>
 
-    <p>I hope you have enjoyed this {{ page.type() | lower }}. If yes, please consider supporting my work — my mission is to spend more time maintaining the dozens of projects that I've written/collaborated on over the years and continue developing new projects to PHP development more productive and enjoyable.</p>
+    <p>I hope you have enjoyed this {{ page.type() | lower }}. If yes, please consider supporting my work — my mission is to spend more time maintaining the dozens of projects that I've written/collaborated on over the years and continue developing new projects to make PHP development more productive and enjoyable.</p>
 
     <p>⇢ <a class="text-bold" href="https://github.com/sponsors/nunomaduro">github.com/sponsors/nunomaduro</a></p>
 {% endblock %}


### PR DESCRIPTION
This patch updates the message on posts to resolve a typo.

So it now reads:

I hope you have enjoyed this article. If yes, please consider supporting my work — my mission is to spend more time maintaining the dozens of projects that I've written/collaborated on over the years and continue developing new projects to make PHP development more productive and enjoyable.

Instead of:

I hope you have enjoyed this article. If yes, please consider supporting my work — my mission is to spend more time maintaining the dozens of projects that I've written/collaborated on over the years and continue developing new projects to PHP development more productive and enjoyable.